### PR TITLE
Update ivy to latest release, make ant depend on ivy

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -7,12 +7,8 @@ class Ant < Formula
 
   bottle :unneeded
 
+  depends_on :ivy => "2.4.0+"
   depends_on :java => "1.8+"
-
-  resource "ivy" do
-    url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
-    sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
-  end
 
   resource "bcel" do
     url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.3-bin.tar.gz"
@@ -28,10 +24,6 @@ class Ant < Formula
       #!/bin/sh
       #{libexec}/bin/ant -lib #{HOMEBREW_PREFIX}/share/ant "$@"
     EOS
-
-    resource("ivy").stage do
-      (libexec/"lib").install Dir["ivy-*.jar"]
-    end
 
     resource("bcel").stage do
       (libexec/"lib").install "bcel-#{resource("bcel").version}.jar"

--- a/Formula/ivy.rb
+++ b/Formula/ivy.rb
@@ -1,7 +1,7 @@
 class Ivy < Formula
   desc "Agile dependency manager"
   homepage "https://ant.apache.org/ivy/"
-  url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.5.0/apache-ivy-2.5.0-rc1-bin.tar.gz"
   sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
 
   bottle :unneeded


### PR DESCRIPTION
In #36260, the option to install ivy alongside ant was dropped. 

This means that it isn't possible to use homebrew-ant with externally-provided ivy any more. This is a problem for Java 11 users, who need newer ivy. 

ivy is packaged separately in homebrew, making this part of the ant formula unnecessary. 

Additionally, the ivy version in homebrew is from 2014. Although the newer version is marked as a release-candidate, it has been available since 2018-03, and is required to work with Java 11, the new Java LTS. 

So: this patch: 
- removes the ivy installation stage from the ant recipe
- makes the ant recipe depend on the ivy recipe
- updates the ivy recipe to 2.5.0-rc0. 

This is another attempt at #20254



- [/] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [/] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [/] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [/] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [/] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
